### PR TITLE
调整颜色选择器面板位置

### DIFF
--- a/src/components/Editor/components/Options.vue
+++ b/src/components/Editor/components/Options.vue
@@ -41,7 +41,7 @@
         <div class="form-item-block">
           <template v-if="firstItem && firstItem.type === 'node'">
             <FormItem label="fill">
-              <ColorPicker v-model="formData.style.fill" hue recommend @on-change="handleChange"></ColorPicker>
+              <ColorPicker placement="top-start" v-model="formData.style.fill" hue recommend @on-change="handleChange"></ColorPicker>
             </FormItem>
             <FormItem label="fillOpacity">
               <Slider
@@ -57,7 +57,7 @@
             </FormItem>
           </template>
           <FormItem label="stroke">
-            <ColorPicker v-model="formData.style.stroke" hue recommend @on-change="handleChange"></ColorPicker>
+            <ColorPicker placement="top-start" v-model="formData.style.stroke" hue recommend @on-change="handleChange"></ColorPicker>
           </FormItem>
           <FormItem label="strokeOpacity">
             <Slider


### PR DESCRIPTION
颜色选择器面板被遮挡，调整位置
调整前
![image](https://user-images.githubusercontent.com/16988840/66746853-9783cf80-eeb5-11e9-8613-d69d719b1d87.png)
调整后
![image](https://user-images.githubusercontent.com/16988840/66746903-b4b89e00-eeb5-11e9-8e08-b184c2a25598.png)
